### PR TITLE
Feature flags

### DIFF
--- a/db/pb_migrations/1739046672_created_feature_flags.js
+++ b/db/pb_migrations/1739046672_created_feature_flags.js
@@ -1,0 +1,80 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = new Collection({
+    "createRule": null,
+    "deleteRule": null,
+    "fields": [
+      {
+        "autogeneratePattern": "[a-z0-9]{15}",
+        "hidden": false,
+        "id": "text3208210256",
+        "max": 15,
+        "min": 15,
+        "name": "id",
+        "pattern": "^[a-z0-9]+$",
+        "presentable": false,
+        "primaryKey": true,
+        "required": true,
+        "system": true,
+        "type": "text"
+      },
+      {
+        "hidden": false,
+        "id": "bool4087400498",
+        "name": "enable",
+        "presentable": false,
+        "required": false,
+        "system": false,
+        "type": "bool"
+      },
+      {
+        "autogeneratePattern": "",
+        "hidden": false,
+        "id": "text1579384326",
+        "max": 0,
+        "min": 0,
+        "name": "name",
+        "pattern": "",
+        "presentable": false,
+        "primaryKey": false,
+        "required": false,
+        "system": false,
+        "type": "text"
+      },
+      {
+        "hidden": false,
+        "id": "autodate2990389176",
+        "name": "created",
+        "onCreate": true,
+        "onUpdate": false,
+        "presentable": false,
+        "system": false,
+        "type": "autodate"
+      },
+      {
+        "hidden": false,
+        "id": "autodate3332085495",
+        "name": "updated",
+        "onCreate": true,
+        "onUpdate": true,
+        "presentable": false,
+        "system": false,
+        "type": "autodate"
+      }
+    ],
+    "id": "pbc_728725186",
+    "indexes": [],
+    "listRule": null,
+    "name": "feature_flags",
+    "system": false,
+    "type": "base",
+    "updateRule": null,
+    "viewRule": null
+  });
+
+  return app.save(collection);
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_728725186");
+
+  return app.delete(collection);
+})

--- a/db/pb_migrations/1739072396_updated_feature_flags.js
+++ b/db/pb_migrations/1739072396_updated_feature_flags.js
@@ -1,0 +1,51 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_728725186")
+
+  // add field
+  collection.fields.addAt(3, new Field({
+    "autogeneratePattern": "",
+    "hidden": false,
+    "id": "text1843675174",
+    "max": 0,
+    "min": 0,
+    "name": "description",
+    "pattern": "",
+    "presentable": false,
+    "primaryKey": false,
+    "required": false,
+    "system": false,
+    "type": "text"
+  }))
+
+  // update field
+  collection.fields.addAt(1, new Field({
+    "hidden": false,
+    "id": "bool4087400498",
+    "name": "enabled",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "bool"
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_728725186")
+
+  // remove field
+  collection.fields.removeById("text1843675174")
+
+  // update field
+  collection.fields.addAt(1, new Field({
+    "hidden": false,
+    "id": "bool4087400498",
+    "name": "enable",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "bool"
+  }))
+
+  return app.save(collection)
+})

--- a/db/pb_migrations/1739072493_updated_feature_flags.js
+++ b/db/pb_migrations/1739072493_updated_feature_flags.js
@@ -1,0 +1,20 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_728725186")
+
+  // update collection data
+  unmarshal({
+    "listRule": ""
+  }, collection)
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_728725186")
+
+  // update collection data
+  unmarshal({
+    "listRule": null
+  }, collection)
+
+  return app.save(collection)
+})

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@headlessui/react": "^2.2.0",
         "@heroicons/react": "^2.2.0",
         "next": "15.1.5",
+        "pocketbase": "^0.25.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hot-toast": "^2.5.1",
@@ -4575,6 +4576,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/pocketbase": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/pocketbase/-/pocketbase-0.25.1.tgz",
+      "integrity": "sha512-2IH0KLI/qMNR/E17C7BGWX2FxW7Tead+igLHOWZ45P56v/NyVT18Jnmddeft+3qWWGL1Hog2F8bc4orWV/+Fcg=="
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.2.0",
     "next": "15.1.5",
+    "pocketbase": "^0.25.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.5.1",

--- a/frontend/src/app/contexts/featureFlags.tsx
+++ b/frontend/src/app/contexts/featureFlags.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import React, { createContext, useContext, ReactNode, useEffect, useState } from 'react';
+import { FeatureFlag, loadFeatureFlags, defaultFeatureFlags } from '@/pocketbase/featureFlags';
+
+const FeatureFlagsContext = createContext<FeatureFlag | undefined>(undefined);
+
+interface FeatureFlagsProviderProps {
+  children: ReactNode;
+  initialFlags?: FeatureFlag;
+}
+
+export const FeatureFlagsProvider: React.FC<FeatureFlagsProviderProps> = ({
+  children,
+  initialFlags,
+}) => {
+  const [flags, setFlags] = useState<FeatureFlag>(initialFlags || defaultFeatureFlags);
+
+  useEffect(() => {
+    if (!initialFlags) {
+      const loadFlags = async () => {
+        try {
+          const loadedFlags = await loadFeatureFlags();
+          setFlags(loadedFlags);
+        } catch (error) {
+          console.error('Failed to load feature flags:', error);
+        }
+      };
+
+      loadFlags();
+    }
+  }, [initialFlags]);
+
+  return (
+    <FeatureFlagsContext.Provider value={flags}>
+      {children}
+    </FeatureFlagsContext.Provider>
+  );
+};
+
+// Utility hook to check a specific feature flag
+export const useFeatureFlag = (flagName: keyof FeatureFlag): boolean => {
+  const context = useContext(FeatureFlagsContext);
+  if (context === undefined) {
+    throw new Error('useFeatureFlags must be used within a FeatureFlagsProvider');
+  }
+  return context[flagName];
+};

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, DM_Sans } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from './contexts/auth';
 import { CartProvider } from './contexts/cart';
+import { FeatureFlagsProvider } from './contexts/featureFlags';
 import { Toaster } from 'react-hot-toast';
 import Header from '@/components/Header';
 
@@ -35,12 +36,14 @@ export default function RootLayout({
       <body
         className={`${inter.variable} ${dmSans.variable} font-sans antialiased`}
       >
-        <AuthProvider>
-          <CartProvider>
-            <Header />
-            {children}
-          </CartProvider>
-        </AuthProvider>
+        <FeatureFlagsProvider>
+          <AuthProvider>
+            <CartProvider>
+              <Header />
+              {children}
+            </CartProvider>
+          </AuthProvider>
+        </FeatureFlagsProvider>
         <Toaster position="bottom-right" />
       </body>
     </html>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { BuildingStorefrontIcon } from '@heroicons/react/24/outline';
 import { SearchProvider } from '@/app/contexts/search';
 import { Search } from '@/components/Search';
+import { useFeatureFlag } from '@/app/contexts/featureFlags';
 
 interface Store {
   id: string;
@@ -20,6 +21,7 @@ export default function Page() {
   const [stores, setStores] = useState<Store[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const productSearchEnabled = useFeatureFlag('product_search')
 
   useEffect(() => {
     const fetchStores = async () => {
@@ -72,8 +74,7 @@ export default function Page() {
   }
 
   return (
-    <SearchProvider>
-      <main className="min-h-[calc(100vh-64px)] bg-[#F5F2EB]">
+    <main className="min-h-[calc(100vh-64px)] bg-[#F5F2EB]">
       {/* Hero Section */}
       <div className="bg-white/50 backdrop-blur-sm border-b pt-16">
         <div className="container mx-auto px-4 py-12">
@@ -85,9 +86,11 @@ export default function Page() {
             <p className="text-lg text-[#4A5568]">
               Shop from your favorite local stores with same-day delivery
             </p>
-            <div className="mt-8">
-              <Search />
-            </div>
+            <SearchProvider>
+              <div className="mt-8">
+                { productSearchEnabled && <Search />}
+              </div>
+            </SearchProvider>
           </div>
         </div>
       </div>
@@ -124,6 +127,5 @@ export default function Page() {
         </div>
       </div>
     </main>
-    </SearchProvider>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -21,7 +21,7 @@ export default function Page() {
   const [stores, setStores] = useState<Store[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const productSearchEnabled = useFeatureFlag('product_search')
+  const productSearchEnabled = useFeatureFlag('product_search');
 
   useEffect(() => {
     const fetchStores = async () => {
@@ -87,9 +87,7 @@ export default function Page() {
               Shop from your favorite local stores with same-day delivery
             </p>
             <SearchProvider>
-              <div className="mt-8">
                 { productSearchEnabled && <Search />}
-              </div>
             </SearchProvider>
           </div>
         </div>

--- a/frontend/src/app/store/[id]/StoreContent.tsx
+++ b/frontend/src/app/store/[id]/StoreContent.tsx
@@ -1,12 +1,10 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useAuth } from '../../contexts/auth';
 import { useCart } from '../../contexts/cart';
 import { toast } from 'react-hot-toast';
 import { FaInstagram, FaFacebook, FaXTwitter } from 'react-icons/fa6';
 import { SiBluesky } from 'react-icons/si';
-import Link from 'next/link';
 import { ClockIcon, MapPinIcon } from '@heroicons/react/24/outline';
 
 interface Store {
@@ -39,7 +37,6 @@ export default function StoreContent({ storeId }: { storeId: string }) {
 
   // Check if cart has items from a different store
   const hasItemsFromDifferentStore = cartItems.length > 0 && cartItems[0].store !== storeId;
-  const currentCartStoreName = hasItemsFromDifferentStore ? store?.name : null;
 
   useEffect(() => {
     const fetchStoreAndItems = async () => {
@@ -58,13 +55,11 @@ export default function StoreContent({ storeId }: { storeId: string }) {
           throw new Error('Failed to fetch store items');
         }
         const itemsData = await itemsResponse.json();
-        
         // Add mock image URLs to items
         const itemsWithImages = itemsData.map((item: StoreItem) => ({
           ...item,
           imageUrl: `https://picsum.photos/seed/${item.id}/400/300`
         }));
-        
         setItems(itemsWithImages);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch store data');
@@ -221,4 +216,4 @@ export default function StoreContent({ storeId }: { storeId: string }) {
       </div>
     </main>
   );
-} 
+}

--- a/frontend/src/components/Search.tsx
+++ b/frontend/src/components/Search.tsx
@@ -1,25 +1,29 @@
-'use client';
+"use client";
 
-import { useState, useEffect, useRef } from 'react';
-import { useSearch } from '@/app/contexts/search';
-import { SearchItem } from '@/app/contexts/search';
+import { useState, useEffect, useRef } from "react";
+import { useSearch } from "@/app/contexts/search";
+import { SearchItem } from "@/app/contexts/search";
 
 export function Search() {
   const { setSearchItems, setIsLoading, isLoading } = useSearch();
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState("");
   const [isFocused, setIsFocused] = useState(false);
   const searchTimeout = useRef<NodeJS.Timeout | null>(null);
-  const baseAPIUrl = 'http://localhost:4100';
-  const productIndex = 'products';
+  const baseAPIUrl = "http://localhost:4100";
+  const productIndex = "products";
 
   const handleSearch = async (searchQuery: string) => {
     try {
       setIsLoading(true);
-      const response = await fetch(`${baseAPIUrl}/api/search?query=${encodeURIComponent(searchQuery)}&index=${productIndex}`);
+      const response = await fetch(
+        `${baseAPIUrl}/api/search?query=${encodeURIComponent(
+          searchQuery,
+        )}&index=${productIndex}`,
+      );
       const { hits } = await response.json();
       setSearchItems(hits as SearchItem[]);
     } catch (error) {
-      console.error('Search failed:', error);
+      console.error("Search failed:", error);
       setSearchItems([]);
     } finally {
       setIsLoading(false);
@@ -47,62 +51,64 @@ export function Search() {
   }, [query]);
 
   return (
-    <div className="relative w-full max-w-xl mx-auto">
-      <div
-        className={`flex items-center px-4 py-2 bg-white rounded-lg border transition-all duration-200 ${
-          isFocused
-            ? 'border-blue-500 shadow-lg ring-2 ring-blue-100'
-            : 'border-gray-200 shadow-sm'
-        }`}
-      >
-        <svg
-          className={`w-5 h-5 transition-colors duration-200 ${
-            isFocused ? 'text-blue-500' : 'text-gray-400'
+    <div className="mt-8">
+      <div className="relative w-full max-w-xl mx-auto">
+        <div
+          className={`flex items-center px-4 py-2 bg-white rounded-lg border transition-all duration-200 ${
+            isFocused
+              ? "border-blue-500 shadow-lg ring-2 ring-blue-100"
+              : "border-gray-200 shadow-sm"
           }`}
-          fill="none"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="2"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
         >
-          <path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-        </svg>
-        <input
-          type="text"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
-          placeholder="Search for coffee..."
-          className="w-full px-3 py-1 text-gray-700 bg-transparent outline-none placeholder-gray-400"
-          aria-label="Search"
-        />
-        {query && (
-          <button
-            onClick={() => setQuery('')}
-            className="p-1 text-gray-400 hover:text-gray-600 focus:outline-none"
-            aria-label="Clear search"
+          <svg
+            className={`w-5 h-5 transition-colors duration-200 ${
+              isFocused ? "text-blue-500" : "text-gray-400"
+            }`}
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
           >
-            <svg
-              className="w-4 h-4"
-              fill="none"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
+            <path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            placeholder="Search for coffee..."
+            className="w-full px-3 py-1 text-gray-700 bg-transparent outline-none placeholder-gray-400"
+            aria-label="Search"
+          />
+          {query && (
+            <button
+              onClick={() => setQuery("")}
+              className="p-1 text-gray-400 hover:text-gray-600 focus:outline-none"
+              aria-label="Clear search"
             >
-              <path d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
+        {(query || isLoading) && (
+          <div className="absolute w-full mt-2 bg-white rounded-lg shadow-lg border border-gray-200 overflow-hidden z-50">
+            <SearchResults />
+          </div>
         )}
       </div>
-      {(query || isLoading) && (
-        <div className="absolute w-full mt-2 bg-white rounded-lg shadow-lg border border-gray-200 overflow-hidden z-50">
-          <SearchResults />
-        </div>
-      )}
     </div>
   );
 }
@@ -132,7 +138,10 @@ const SearchResults = () => {
   return (
     <div className="space-y-2">
       {searchItems.map((item) => (
-        <div key={item.id} className="flex items-center p-2 bg-white rounded-lg border border-gray-200">
+        <div
+          key={item.id}
+          className="flex items-center p-2 bg-white rounded-lg border border-gray-200"
+        >
           <img className="w-12 h-12 mr-4" src={item.imageUrl} alt={item.name} />
           <div>
             <h3 className="text-sm font-semibold">{item.name}</h3>

--- a/frontend/src/pocketbase/featureFlags.ts
+++ b/frontend/src/pocketbase/featureFlags.ts
@@ -1,0 +1,30 @@
+import pb from './index';
+
+export interface FeatureFlag {
+  [key: string]: boolean;
+}
+
+export const defaultFeatureFlags: FeatureFlag = {
+  "product_search": false,
+};
+
+// Function to load feature flags from the database
+export const loadFeatureFlags = async (): Promise<FeatureFlag> => {
+  try {
+    const flags = { ...defaultFeatureFlags };
+
+    // Fetch feature flags from the database
+    const results = await pb.collection('feature_flags').getFullList();
+
+    // Convert the database flags into our FeatureFlags format
+    results.forEach((flag) => {
+      flags[flag.name] = flag.enabled;
+    });
+
+    console.log('Loaded feature flags:', flags);
+    return flags;
+  } catch (error) {
+    console.error('Failed to load feature flags:', error);
+    return defaultFeatureFlags;
+  }
+};

--- a/frontend/src/pocketbase/index.ts
+++ b/frontend/src/pocketbase/index.ts
@@ -1,0 +1,5 @@
+import PocketBase from 'pocketbase';
+
+const pb = new PocketBase('http://localhost:8090');
+
+export default pb;


### PR DESCRIPTION
closes #18 

### Changes
- adds a pocketbase collection for feature flag management 
- adds `useFeatureFlag` hook

### Example usage:
```typescript
const productSearchEnabled = useFeatureFlag('product_search')
```

If the row is missing in feature_flags collection, a default will be used.
Check out `defaultFeatureFlags` in `pocketbase/featureFlags.ts`